### PR TITLE
Fixed the dark mode when using chrome

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -97,7 +97,7 @@
   --secondaryToolbarButton-documentProperties-icon: url(images/secondaryToolbarButton-documentProperties.svg);
 }
 
-@media (prefers-color-scheme: dark) {
+
   :root {
     --main-color: rgba(249, 249, 250, 1);
     --body-bg-color: rgba(42, 42, 46, 1);
@@ -139,7 +139,7 @@
      * here; hence why we still have two versions of this particular image. */
     --loading-icon: url(images/loading-dark.svg);
   }
-}
+
 
 * {
   padding: 0;


### PR DESCRIPTION
Implemnented pdf.js in my application, but when trying to open the application on chrome if my browser is in Dark mode the pdf viewer is in light mode and the orther way around. This is fixed getting rid of "prefers-color-scheme: dark".